### PR TITLE
Remove laminas-zendframework-bridge.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "php": "^7.3 || ~8.0.0"
     },
     "suggest": {
         "ext-iconv": "*",


### PR DESCRIPTION
Projects that use laminas-escaper that are not using it as part of a legacy zendframework application don't need the BC autoloading bridge.

See - https://github.com/laminas/laminas-escaper/issues/11#issuecomment-826844368

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description


- Are you fixing a BC Break?

yes.

  - How do you reproduce it?

Composer update

  - What was the previous behavior?
  
Install zendbridge-framework.
  
  - What is the current behavior?

Don't install zendbridge-framework.


