### PR TITLE
Stricter input/output type declaration, matching original type signatures from `2.0.0-beta5` release

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
   <file src="src/Escaper.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_string($encoding)</code>
-    </DocblockTypeContradiction>
     <MixedArgument occurrences="10">
       <code>$chr</code>
       <code>$chr</code>
@@ -42,10 +39,7 @@
       <code>array&lt;string, array{0: string, 1: string}&gt;</code>
       <code>array&lt;string, array{0: string}&gt;</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="1">
-      <code>1</code>
-    </InvalidScalarArgument>
-    <MissingReturnType occurrences="10">
+    <MissingReturnType occurrences="9">
       <code>testCssEscapingReturnsStringIfContainsOnlyDigits</code>
       <code>testCssEscapingReturnsStringIfZeroLength</code>
       <code>testHtmlAttributeEscapingEscapesOwaspRecommendedRanges</code>
@@ -54,7 +48,6 @@
       <code>testReturnsEncodingFromGetter</code>
       <code>testSettingEncodingToEmptyStringShouldThrowException</code>
       <code>testSettingEncodingToInvalidValueShouldThrowException</code>
-      <code>testSettingEncodingToNonStringShouldThrowException</code>
       <code>testUnicodeCodepointConversionToUtf8</code>
     </MissingReturnType>
   </file>

--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -132,10 +132,10 @@ class Escaper
      * Constructor: Single parameter allows setting of global encoding for use by
      * the current object.
      *
-     * @param string $encoding
+     * @param string|null $encoding
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($encoding = null)
+    public function __construct(?string $encoding = null)
     {
         if ($encoding !== null) {
             if (! is_string($encoding)) {
@@ -186,7 +186,7 @@ class Escaper
      * @param string $string
      * @return string
      */
-    public function escapeHtml($string)
+    public function escapeHtml(string $string)
     {
         return htmlspecialchars($string, $this->htmlSpecialCharsFlags, $this->encoding);
     }
@@ -199,7 +199,7 @@ class Escaper
      * @param string $string
      * @return string
      */
-    public function escapeHtmlAttr($string)
+    public function escapeHtmlAttr(string $string)
     {
         $string = $this->toUtf8($string);
         if ($string === '' || ctype_digit($string)) {
@@ -222,7 +222,7 @@ class Escaper
      * @param string $string
      * @return string
      */
-    public function escapeJs($string)
+    public function escapeJs(string $string)
     {
         $string = $this->toUtf8($string);
         if ($string === '' || ctype_digit($string)) {
@@ -241,7 +241,7 @@ class Escaper
      * @param string $string
      * @return string
      */
-    public function escapeUrl($string)
+    public function escapeUrl(string $string)
     {
         return rawurlencode($string);
     }
@@ -253,7 +253,7 @@ class Escaper
      * @param string $string
      * @return string
      */
-    public function escapeCss($string)
+    public function escapeCss(string $string)
     {
         $string = $this->toUtf8($string);
         if ($string === '' || ctype_digit($string)) {

--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -7,12 +7,10 @@ namespace Laminas\Escaper;
 use function bin2hex;
 use function ctype_digit;
 use function function_exists;
-use function gettype;
 use function hexdec;
 use function htmlspecialchars;
 use function iconv;
 use function in_array;
-use function is_string;
 use function mb_convert_encoding;
 use function ord;
 use function preg_match;
@@ -132,7 +130,6 @@ class Escaper
      * Constructor: Single parameter allows setting of global encoding for use by
      * the current object.
      *
-     * @param string|null $encoding
      * @throws Exception\InvalidArgumentException
      */
     public function __construct(?string $encoding = null)
@@ -178,7 +175,6 @@ class Escaper
      * Escape a string for the HTML Body context where there are very few characters
      * of special meaning. Internally this will use htmlspecialchars().
      *
-     * @param string $string
      * @return string
      */
     public function escapeHtml(string $string)
@@ -191,7 +187,6 @@ class Escaper
      * to escape that are not covered by htmlspecialchars() to cover cases where an attribute
      * might be unquoted or quoted illegally (e.g. backticks are valid quotes for IE).
      *
-     * @param string $string
      * @return string
      */
     public function escapeHtmlAttr(string $string)
@@ -214,7 +209,6 @@ class Escaper
      * Backslash escaping is not used as it still leaves the escaped character as-is and so
      * is not useful in a HTML context.
      *
-     * @param string $string
      * @return string
      */
     public function escapeJs(string $string)
@@ -233,7 +227,6 @@ class Escaper
      * an entire URI - only a subcomponent being inserted. The function is a simple proxy
      * to rawurlencode() which now implements RFC 3986 since PHP 5.3 completely.
      *
-     * @param string $string
      * @return string
      */
     public function escapeUrl(string $string)
@@ -245,7 +238,6 @@ class Escaper
      * Escape a string for the CSS context. CSS escaping can be applied to any string being
      * inserted into CSS and escapes everything except alphanumerics.
      *
-     * @param string $string
      * @return string
      */
     public function escapeCss(string $string)

--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -138,11 +138,6 @@ class Escaper
     public function __construct(?string $encoding = null)
     {
         if ($encoding !== null) {
-            if (! is_string($encoding)) {
-                throw new Exception\InvalidArgumentException(
-                    static::class . ' constructor parameter must be a string, received ' . gettype($encoding)
-                );
-            }
             if ($encoding === '') {
                 throw new Exception\InvalidArgumentException(
                     static::class . ' constructor parameter does not allow a blank value'

--- a/test/EscaperTest.php
+++ b/test/EscaperTest.php
@@ -22,15 +22,6 @@ class EscaperTest extends TestCase
         $this->escaper = new Escaper('UTF-8');
     }
 
-    public function testSettingEncodingToNonStringShouldThrowException()
-    {
-        $this->expectExceptionMessage(
-            "Laminas\Escaper\Escaper constructor parameter must be a string, received integer"
-        );
-        $this->expectException(InvalidArgumentException::class);
-        new Escaper(1);
-    }
-
     public function testSettingEncodingToEmptyStringShouldThrowException()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
Signed-off-by: Carnage <t.carnage@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The introduction of strict types in the file heading is propagated to calling code as the required types are missing from the method signatures. This PR adds the types and resolves the BC break.

While adding types to the methods could be considered a BC break in itself, I cannot conceive of any sensible use case that this change would impact.