### PR TITLE
Allow bool $doubleEncode optional param to escapeHtml()

### DIFF
--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -190,9 +190,9 @@ class Escaper
      *
      * @return string
      */
-    public function escapeHtml(string $string)
+    public function escapeHtml(string $string, bool $double_encode = true)
     {
-        return htmlspecialchars($string, $this->htmlSpecialCharsFlags, $this->encoding);
+        return htmlspecialchars($string, $this->htmlSpecialCharsFlags, $this->encoding, $double_encode);
     }
 
     /**

--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -190,9 +190,9 @@ class Escaper
      *
      * @return string
      */
-    public function escapeHtml(string $string, bool $double_encode = true)
+    public function escapeHtml(string $string, bool $doubleEncode = true)
     {
-        return htmlspecialchars($string, $this->htmlSpecialCharsFlags, $this->encoding, $double_encode);
+        return htmlspecialchars($string, $this->htmlSpecialCharsFlags, $this->encoding, $doubleEncode);
     }
 
     /**


### PR DESCRIPTION
Allows $doubleEncode to be sent to htmlspecialchars() in html context.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

Tell us about why this change is necessary:
- Are you adding something the library currently does not support?
> Yes
  - Why should it be added?
> current behavior in html context causes `&amp; &` to be encoded as `&amp;amp; &amp;`.  `htmlspecialchars()` has a fourth optional parameter `bool $double_encode = true`, so by default it's double encoding. 
  - What will it enable?
> This change will allow users to call `escapeHtml()` with a 2nd (optional) parameter which tells it not to double encode parts of the string which are already encoded.
  - How will the code be used?
> `escapeHtml('&amp; &', false);` would yield `&amp; &amp;`. `escapeHtml('&amp; &');` would still yield `&amp;amp; &amp;`
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN. 
> BC will not be broken because the 2nd parameter is an optional parameter equal to current behavior of double encoding. 2.14.x targeted