### PR TITLE
Update escaping-html-attributes.md changed HTTP typo to HTML

### DIFF
--- a/docs/book/escaping-html-attributes.md
+++ b/docs/book/escaping-html-attributes.md
@@ -5,7 +5,7 @@ not overlooked completely by developers. Regular [HTML
 escaping](escaping-html.md) can be used for escaping HTML attributes *only* if
 the attribute value can be **guaranteed as being properly quoted**! To avoid
 confusion, we recommend always using the HTML Attribute escaper method when
-dealing with HTTP attributes specifically.
+dealing with HTML attributes specifically.
 
 To escape data for an HTML Attribute, use `Laminas\Escaper\Escaper`'s
 `escapeHtmlAttr()` method.  Internally it will convert the data to UTF-8, check


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I believe "HTTP attributes" is a typo here, should be HTML.
