### PR TITLE
Add getEncoding to EscaperInterface.

### DIFF
--- a/src/Escaper.php
+++ b/src/Escaper.php
@@ -173,11 +173,7 @@ class Escaper implements EscaperInterface
             fn(array $matches): string => $this->cssMatcher($matches);
     }
 
-    /**
-     * Return the encoding that all output/input is expected to be encoded in.
-     *
-     * @return non-empty-string
-     */
+    /** @inheritDoc */
     public function getEncoding()
     {
         return $this->encoding;

--- a/src/EscaperInterface.php
+++ b/src/EscaperInterface.php
@@ -10,6 +10,13 @@ namespace Laminas\Escaper;
 interface EscaperInterface
 {
     /**
+     * Return the encoding that all output/input is expected to be encoded in.
+     *
+     * @return non-empty-string
+     */
+    public function getEncoding();
+
+    /**
      * Escape a string for the HTML Body context where there are very few characters
      * of special meaning. Internally this will use htmlspecialchars().
      *


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Thank you for including the EscaperInterface in release 2.17.0. Unfortunately, when I contributed the interface, it appears that I neglected to include the `getEncoding()` method, so when I tried introducing the interface into `laminas-view`, key functionality was missing. This PR adds the missing method to the interface. Apologies for the oversight!

I think addressing this oversight qualifies as a bug fix (though it's also technically a BC break, as the failing check points out -- but a BC break to something that's not really useful without this change and likely isn't in use yet). When I target the 2.17.x branch, the EscaperInterface does not exist there; I wonder if the release branches are not in the expected state, or if I'm just doing something wrong. In any case, I am targeting this PR against 2.18.x since that was the only branch I could find that included the EscaperInterface. Happy to cherry-pick my changes somewhere else and repoint the PR if there's a better target branch.
